### PR TITLE
Update example to use reverse port forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 Info about the required setup and how to run these tests can be found here:
-https://altom.com/alttester/docs/sdk/pages/alttester-with-appium.html
+https://alttester.com/docs/sdk/latest/pages/alttester-with-appium.html
 
 ### Running the tests on Android
-The app is provided at https://altom.com/app/uploads/AltTester/TrashCat/TrashCatAndroid.zip and needs to be included unzipped under project.
+**Prerequisite**:
+
+❗ Starting with version 2.0.0, the AltTester Desktop must be running on your PC while the tests are running. You can take it form https://alttester.com/alttester/#pricing.
+
+**How to run the tests:**
+1. Open the AltTester Desktop
+2. The app is provided at https://alttester.com/app/uploads/AltTester/TrashCat/TrashCatAndroid2_0_1.zip nd needs to be included unzipped under project.
+3. `./run-tests_android.sh` command in your terminal

--- a/README.md
+++ b/README.md
@@ -8,5 +8,5 @@ https://alttester.com/docs/sdk/latest/pages/alttester-with-appium.html
 
 **How to run the tests:**
 1. Open the AltTester Desktop
-2. The app is provided at https://alttester.com/app/uploads/AltTester/TrashCat/TrashCatAndroid2_0_1.zip nd needs to be included unzipped under project.
+2. The app is provided at https://alttester.com/app/uploads/AltTester/TrashCat/TrashCatAndroid2_0_1.zip and needs to be included unzipped under project.
 3. `./run-tests_android.sh` command in your terminal

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ https://alttester.com/docs/sdk/latest/pages/alttester-with-appium.html
 ### Running the tests on Android
 **Prerequisite**:
 
-❗ Starting with version 2.0.0, the AltTester Desktop must be running on your PC while the tests are running. You can take it form https://alttester.com/alttester/#pricing.
+❗ Starting with version 2.0.0, the AltTester Desktop must be running on your PC while the tests are running. You can take it from https://alttester.com/alttester/#pricing.
 
 **How to run the tests:**
 1. Open the AltTester Desktop

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pytest
 Appium-Python-Client
-AltTester-Driver==1.8.0
+AltTester-Driver==2.0.1

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -26,12 +26,12 @@ class TestBase(unittest.TestCase):
         cls.desired_caps['automationName'] = os.getenv('APPIUM_AUTOMATION', 'UIAutomator2')
         cls.appium_driver = webdriver.Remote('http://localhost:4723/wd/hub', cls.desired_caps)
         print("Appium driver started")
-        cls.setup_port_forwarding()
+        cls.setup_reverse_port_forwarding()
         time.sleep(10)
         cls.altdriver = AltDriver()
 
     @classmethod
-    def setup_port_forwarding(cls):
+    def setup_reverse_port_forwarding(cls):
         try:
             AltReversePortForwarding.remove_reverse_port_forwarding_android()
         except:
@@ -47,6 +47,7 @@ class TestBase(unittest.TestCase):
         print("\nEnding")
         try:
             AltReversePortForwarding.remove_reverse_port_forwarding_android()
+            print("Reverse port forwarding removed")
         except:
             print("No adb forward was present")
         cls.altdriver.stop()

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -3,7 +3,7 @@ import sys
 import time
 import unittest
 
-from alttester import AltDriver, AltPortForwarding
+from alttester import AltDriver, AltReversePortForwarding
 from appium import webdriver
 
 sys.path.append(os.path.dirname(__file__))
@@ -33,23 +33,21 @@ class TestBase(unittest.TestCase):
     @classmethod
     def setup_port_forwarding(cls):
         try:
-            AltPortForwarding.remove_all_forward_android()
+            AltReversePortForwarding.RemoveReversePortForwardingAndroid
         except:
             print("No adb forward was present")
-        try:
-            AltPortForwarding.kill_all_iproxy_process()
-        except:
-            print("No iproxy forward was present")
-
         if cls.platform == 'android':
-            AltPortForwarding.forward_android()
+            AltReversePortForwarding.ReversePortForwardingAndroid();
             print("Port forwarded (Android).")
         else:
-            AltPortForwarding.forward_ios()
-            print("Port forwarded (iOS).")
+            print("Reverse port forwarding is available only for Android")
 
     @classmethod
     def tearDownClass(cls):
         print("\nEnding")
+        try:
+            AltReversePortForwarding.RemoveReversePortForwardingAndroid
+        except:
+            print("No adb forward was present")
         cls.altdriver.stop()
         cls.appium_driver.quit()

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -33,11 +33,11 @@ class TestBase(unittest.TestCase):
     @classmethod
     def setup_port_forwarding(cls):
         try:
-            AltReversePortForwarding.RemoveReversePortForwardingAndroid
+            AltReversePortForwarding.remove_reverse_port_forwarding_android()
         except:
             print("No adb forward was present")
         if cls.platform == 'android':
-            AltReversePortForwarding.ReversePortForwardingAndroid();
+            AltReversePortForwarding.reverse_port_forwarding_android()
             print("Port forwarded (Android).")
         else:
             print("Reverse port forwarding is available only for Android")
@@ -46,7 +46,7 @@ class TestBase(unittest.TestCase):
     def tearDownClass(cls):
         print("\nEnding")
         try:
-            AltReversePortForwarding.RemoveReversePortForwardingAndroid
+            AltReversePortForwarding.remove_reverse_port_forwarding_android()
         except:
             print("No adb forward was present")
         cls.altdriver.stop()


### PR DESCRIPTION
In this ticket, I also deleted the `KillAllIproxyProcess` method because it is no more present into the API docs
Additionally:
- updated the driver
- updated readme

Results after changes:
![image](https://github.com/alttester/EXAMPLES-Python-Android-with-Appium-AltTrashCat/assets/113912901/f95ea062-02b3-4847-8220-d2dbdb7b849c)
